### PR TITLE
camb 2.0.0

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: camb
-  version: "1.6.5"
+  version: "2.0.0"
   unix_url: 'https://github.com/cmbant/CAMB/archive/${{ version }}.tar.gz'
   win_url: 'https://camb.info/camb_wheel.php?package=camb&version=${{ version }}&template=py3-none-win_amd64'
 
@@ -12,14 +12,14 @@ package:
 
 source:
   url: ${{ unix_url if unix else win_url }}
-  sha256: ${{ '1965db83f15fcfb0617fafb396c84f8309a51850792052e57040d8f2f9b63779' if unix else 'dc98ded515040ca2b26309ac2092c8fadddd024f2f38c99db30fc991e330bca0' }}
+  sha256: ${{ 'ab72e80729cdba2907b243ba6680c3d67f2d21aeb279ccefe81089f75501904f' if unix else '548167e87319163c334de661a8a86d3d2a482b9ae105090f79c23d3d74425573' }}
   patches:
     - if: unix
       then: makefile_flags_0001.patch
 
 build:
-  number: 1
-  skip: match(python, "<3.10")
+  number: 0
+  skip: match(python, "<3.11")
   script:
     - if: win
       then:
@@ -80,29 +80,15 @@ about:
   license_file: LICENSE
   summary: Code for Anisotropies in the Microwave Background
   description: |
-    Code for Anisotropies in the Microwave Background
-    by Antony Lewis and Anthony Challinor
+    CAMB is a cosmology code for calculating cosmological observables, including CMB,
+    lensing, source count and 21cm angular power spectra, matter power spectra,
+    transfer functions and background evolution, by Antony Lewis and Anthony Challinor.
+    The code is in Python, with numerical code implemented in fast modern Fortran.
 
-    Features:
-    - Support for closed, open and flat models
-    - Scalar, vector and tensor modes including polarization
-    - Output Cl, matter transfer functions, matter power spectrum and σ8
-    - Fast computation to ~0.3-0.1% accuracy, with controllable accuracy level
-    - Relatively structured and easily extendable Fortran 90 code
-    - Efficient support for massive neutrinos
-    - Absolute computations from correctly normalized initial power spectra
-    - Computation of lensed CMB power spectra and lensing potential power spectrum
-    - Internally parallelized for fast execution on multi-processor machines
-    - Use CAMB with CosmoMC for Monte-Carlo parameter estimation
-    - Constant equation of state quintessence (or variable PPF)
-    - Support for general correlated adiabatic/isocurvature initial conditions
-    - Accurate full-sky calculation of lensed power spectra (astro-ph/0502425)
-    - Integrated interface to HALOFIT for non-linear fitting
-    - support for arbitrary neutrino mass splittings
-    - For 21cm, lensing and number count power spectra see this extension
-    - For perturbed recombination and effect on small-scale baryons see this extension
-    - Calculation of local primordial and CMB lensing bispectra
-    - Easy-to-use Python wrapper
+    See the CAMB python example notebook for a quick introduction to how to use the
+    CAMB Python package: https://camb.readthedocs.io/en/latest/CAMBdemo.html
+
+    The python module is "camb". Full documentation: https://camb.readthedocs.io/en/latest/
   homepage: https://camb.info/
   repository: https://github.com/cmbant/CAMB
   documentation: https://camb.info/readme.html


### PR DESCRIPTION
Bumps camb to the 2.0.0 release.

Supersedes #70 — that bot PR (opened for 1.6.6) has been stuck since March on a failing
Azure build, and `main` has since migrated `recipe/meta.yaml` -> `recipe/recipe.yaml`
(rattler-build format), so it now shows unresolvable modify/delete conflicts in the
GitHub UI (`recipe/meta.yaml`, `.azure-pipelines/azure-pipelines-osx.yml`,
`.scripts/run_osx_build.sh`). Rather than fight that, this bumps straight to 2.0.0
(already on PyPI) off current `main`.

Changes:
- `version`: 1.6.5 -> 2.0.0
- `sha256` for both the unix source tarball and the win_amd64 wheel, verified against
  the actual published 2.0.0 artifacts
- `build.number` reset to 0
- `build.skip`: `python<3.10` -> `python<3.11` (camb 2.0.0 requires `python>=3.11`,
  see `pyproject.toml`)
- `about.description` refreshed to match the current upstream long description
  (`docs/README_pypi.rst`); the old accuracy bullet (`~0.3-0.1%`) was stale and has
  already been dropped upstream

#70 can be closed once this merges.
