### PR TITLE
Update about.documentation to readthedocs

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -91,7 +91,7 @@ about:
     The python module is "camb". Full documentation: https://camb.readthedocs.io/en/latest/
   homepage: https://camb.info/
   repository: https://github.com/cmbant/CAMB
-  documentation: https://camb.info/readme.html
+  documentation: https://camb.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Points `about.documentation` at https://camb.readthedocs.io/en/latest/ instead of the old `camb.info/readme.html` (Fortran-only readme). Metadata-only change, in prep for the next real version bump/rebuild — no version, sha256, or build number change needed.